### PR TITLE
Не учитывался параметр SCOPE из переменной окружения

### DIFF
--- a/src/litellm_gigachat/core/token_manager.py
+++ b/src/litellm_gigachat/core/token_manager.py
@@ -138,7 +138,9 @@ def get_global_token_manager() -> TokenManager:
     """Получение глобального экземпляра TokenManager"""
     global _global_token_manager
     if _global_token_manager is None:
-        _global_token_manager = TokenManager()
+        # Читаем scope из переменной окружения, если указан
+        scope = os.environ.get("GIGACHAT_SCOPE", "GIGACHAT_API_PERS")
+        _global_token_manager = TokenManager(scope=scope)
     return _global_token_manager
 
 def get_gigachat_token() -> str:


### PR DESCRIPTION
 ПРОБЛЕМА: Функция get_global_token_manager() создавала TokenManager(……) без параметров, игнорируя переменную окружения GIGACHAT_SCOPE.

  РЕШЕНИЕ: Исправлен файл src/litellm_gigachat/core/token_manager.py:137-144 - теперь функция читает GIGACHAT_SCOPE из переменных окружения перед созданием экземпляра.